### PR TITLE
made home link easier to see/parse for humans

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,7 +7,7 @@
 		{{ $group := index .Params.tags 0 }}
 		<div class="page-title">
 			<h1 class="recipe-title">{{ .Page.Title }}</h1>
-			<h3><strong>~| <a href="{{ .Site.BaseURL }}">home</a></strong><br>
+            <h3><strong><a href="{{ .Site.BaseURL }}">~| go back home</a></strong><br><br>
 				<strong>tags:</strong>
 			{{ range $i := .Params.tags }}
 				{{ $url := ( printf "%s.md" $i ) }}

--- a/layouts/tags/single.html
+++ b/layouts/tags/single.html
@@ -5,7 +5,7 @@
 <div class="recipe-page col-md-3 col-8">
 	<div class="page-title">
 		<h1>{{ .Page.Title }}</h1>
-		<h2>~| <a href="{{ .Site.BaseURL }}"><strong>home</strong></a></h2>
+		<h2><a href="{{ .Site.BaseURL }}"><strong>~| go back home</strong></a></h2>
 	</div>
 	{{ .Content }}
 	{{ $group := index .Params.tags 0 }}


### PR DESCRIPTION
each page has a link back to the main page and the link text says 'home'. i think this is fine but it took me a minute to spot how to get home on mobile, as i couldn't hover over it to see the decoration.

to fix, i updated the link text to say 'go back home' and included another line break to more clearly separate the link from the tags section. i also included the `~|` decoration into the &lt;a&gt; tag for basically no reason. i was gonna add an arrow material icon or something, but i felt it didn't match the site's aesthetic that well.

feel free to edit or disregard this pr.